### PR TITLE
Add preemptible instances support

### DIFF
--- a/novaclient/tests/unit/v2/test_servers.py
+++ b/novaclient/tests/unit/v2/test_servers.py
@@ -308,6 +308,21 @@ class ServersTest(utils.FixturedTestCase):
         body = jsonutils.loads(self.requests.last_request.body)
         self.assertEqual(test_password, body['server']['adminPass'])
 
+    def test_create_server_preemptible(self):
+        # FIXME(aloga): probably this should go in a microversion test if the
+        # API code gets merged upstream
+        s = self.cs.servers.create(
+            name="My server",
+            image=1,
+            flavor=1,
+            preemptible=True
+        )
+        self.assert_request_id(s, fakes.FAKE_REQUEST_ID_LIST)
+        self.assert_called('POST', '/servers')
+        self.assertIsInstance(s, servers.Server)
+        body = jsonutils.loads(self.requests.last_request.body)
+        self.assertTrue(body['server']['preemptible'])
+
     def test_create_server_userdata_bin(self):
         with tempfile.TemporaryFile(mode='wb+') as bin_file:
             original_data = os.urandom(1024)

--- a/novaclient/tests/unit/v2/test_shell.py
+++ b/novaclient/tests/unit/v2/test_shell.py
@@ -171,6 +171,20 @@ class ShellTest(utils.TestCase):
             }},
         )
 
+    def test_boot_preemtible(self):
+        self.run_command('boot --flavor 1 --image 1 --preemptible some-server')
+        self.assert_called_anytime(
+            'POST', '/servers',
+            {'server': {
+                'flavorRef': '1',
+                'name': 'some-server',
+                'imageRef': '1',
+                'preemptible': True,
+                'min_count': 1,
+                'max_count': 1,
+            }},
+        )
+
     def test_boot_user_data(self):
         testfile = os.path.join(os.path.dirname(__file__), 'testfile.txt')
         with open(testfile) as testfile_fd:

--- a/novaclient/v2/servers.py
+++ b/novaclient/v2/servers.py
@@ -583,7 +583,7 @@ class ServerManager(base.BootingManagerWithFind):
               block_device_mapping_v2=None, nics=None, scheduler_hints=None,
               config_drive=None, admin_pass=None, disk_config=None,
               access_ip_v4=None, access_ip_v6=None, description=None,
-              **kwargs):
+              preemptible=False, **kwargs):
         """
         Create (boot) a new server.
         """
@@ -707,6 +707,9 @@ class ServerManager(base.BootingManagerWithFind):
 
         if description:
             body['server']['description'] = description
+
+        if preemptible:
+            body['server']['preemptible'] = True
 
         return self._create(resource_url, body, response_key,
                             return_raw=return_raw, **kwargs)

--- a/novaclient/v2/shell.py
+++ b/novaclient/v2/shell.py
@@ -353,7 +353,8 @@ def _boot(cs, args):
         config_drive=config_drive,
         admin_pass=args.admin_pass,
         access_ip_v4=args.access_ip_v4,
-        access_ip_v6=args.access_ip_v6)
+        access_ip_v6=args.access_ip_v6,
+        preemptible=args.preemptible)
 
     if 'description' in args:
         boot_kwargs["description"] = args.description
@@ -559,6 +560,12 @@ def _boot(cs, args):
     action="store_true",
     default=False,
     help=_('Report the new server boot progress until it completes.'))
+@utils.arg(
+    '--preemptible',
+    dest='preemptible',
+    action="store_true",
+    default=False,
+    help=_('Indicates that the requested instance is preemptible'))
 @utils.arg(
     '--admin-pass',
     dest='admin_pass',


### PR DESCRIPTION
Launching a preemptible instance can be done by passing an additional
argument to the server creation request: "preemptible".

Change-Id: I40b9aca0ee521592a56fa45943d4fcbd6ffad009
